### PR TITLE
Add ability to auto-detect line endings.

### DIFF
--- a/libraries/csvimport.php
+++ b/libraries/csvimport.php
@@ -30,10 +30,16 @@ class Csvimport {
      * @access  public
      * @param   filepath        string  Location of the CSV file
      * @param   column_headers  array   Alternate values that will be used for array keys instead of first line of CSV
+     * @param   detect_line_endings  boolean  When true sets the php INI settings to allow script to detect line endings. Needed for CSV files created on Macs.
      * @return  array
      */
-    public function get_array($filepath='', $column_headers='')
+    public function get_array($filepath='', $column_headers='', $detect_line_endings=FALSE)
     {
+        // If true, auto detect row endings
+        if($detect_line_endings){
+            ini_set("auto_detect_line_endings", TRUE);
+        }
+
         // If file exists, set filepath
         if(file_exists($filepath))
         {


### PR DESCRIPTION
When a CSV is created on a Mac, the line endings aren't always used by
fgetcsv. We account for this by setting auto_detect_line_endings to true
in the PHP ini.

By using ini_set() this setting is updated for this script's run and
then set back to the standard PHP ini on the server.

The reason I added the $detect_line_endings param to get_array() is setting auto_detect_line_endings does come at a server performance cost. So, I think it makes sense to let the developer decide if it's OK to use for his application.
